### PR TITLE
feat(test): add support for strict option

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -1,14 +1,23 @@
 import parse from './parse/index.js';
 
-const test = (str) => {
+/**
+ * Test if a string is a path template.
+ *
+ * @param {string} str
+ * @param {Object} [options={}] - An object.
+ * @param {boolean} [options.strict=true] - A boolean indicating presence of at least one `template-expression` AST node.
+ * @returns {boolean}
+ */
+const test = (str, { strict = false } = {}) => {
   try {
     const parseResult = parse(str);
 
     if (!parseResult.result.success) return false;
+    if (!strict) return true;
 
     const parts = [];
     parseResult.ast.translate(parts);
-    return parts.some(([type]) => type === 'path-template')
+    return parts.some(([type]) => type === 'template-expression')
   } catch {
     return false;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -9,11 +9,11 @@ describe('test', function () {
     assert.isTrue(test('/{entity}/me'));
     assert.isTrue(test('/books/{id}'));
     assert.isTrue(test('/{entity}/{another-entity}/me'));
+    assert.isTrue(test('/'));
+    assert.isTrue(test('/pets/mine'));
   });
 
   it('should not detect expression', function () {
-    assert.isTrue(test('/'));
-    assert.isTrue(test('/pets/mine'));
     assert.isFalse(test(''));
     assert.isFalse(test('1'));
     assert.isFalse(test('{petId}'));
@@ -21,5 +21,27 @@ describe('test', function () {
     assert.isFalse(test(1));
     assert.isFalse(test(null));
     assert.isFalse(test(undefined));
+  });
+
+  context('given strict option', function ()  {
+    specify('should detect as path template', function () {
+      assert.isTrue(test('/{path}', { strict: true }));
+      assert.isTrue(test('/pets/{petId}', { strict: true }));
+      assert.isTrue(test('/{entity}/me', { strict: true }));
+      assert.isTrue(test('/books/{id}', { strict: true }));
+      assert.isTrue(test('/{entity}/{another-entity}/me'));
+    });
+
+    specify('should not detect expression', function () {
+      assert.isFalse(test('/', { strict: true}));
+      assert.isFalse(test('/pets/mine', { strict: true }));
+      assert.isFalse(test(''));
+      assert.isFalse(test('1'));
+      assert.isFalse(test('{petId}'));
+      assert.isFalse(test('/pet/{petId'));
+      assert.isFalse(test(1));
+      assert.isFalse(test(null));
+      assert.isFalse(test(undefined));
+    });
   });
 });


### PR DESCRIPTION
When strict=true, then the input string
is recognized as OpenAPI path template
even though it doesn't contain any template-expression.